### PR TITLE
[#13] - 이미지 다운로드 버튼 워딩 수정

### DIFF
--- a/src/components/image-download-button.tsx
+++ b/src/components/image-download-button.tsx
@@ -16,7 +16,7 @@ export default function ImageDownloadButton({
     const url = resultSrc.src;
 
     const res = await fetch(url);
-    if (!res.ok) throw new Error("이미지 다운로드 실패");
+    if (!res.ok) throw new Error("행운카드 다운로드 실패");
 
     const blob = await res.blob();
     const objectUrl = URL.createObjectURL(blob);
@@ -40,7 +40,7 @@ export default function ImageDownloadButton({
         <Icon name="download" width={16} height={16} />
       </button>
       <span className="text-xs font-medium leading-[180%] tracking-[-0.03em] text-[#EA706C]">
-        이미지 다운로드
+        행운카드 다운로드
       </span>
     </div>
   );


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #13

## 🌱 주요 변경 사항
이미지 다운로드 버튼 워딩 수정 (이미지 -> 행운카드)

## 📸 스크린샷 (선택)
<img width="370" height="637" alt="image" src="https://github.com/user-attachments/assets/43f4a6d5-e68f-4e19-9a1e-3b21a15f1862" />
