### PR TITLE
[#87] - 화이트데이 카카오톡 공유하기 버튼 이미지 크기 조정

### DIFF
--- a/src/components/white-day/kakao-share-button.tsx
+++ b/src/components/white-day/kakao-share-button.tsx
@@ -25,8 +25,8 @@ export default function KakaoShareButton({
         title: "iBe - 행운 뽑기 | 선물이 도착했어요!",
         description: `To. ${gift.receiver}\n${gift.title}`,
         imageUrl: `https://ibe-lucky.vercel.app/white-day/og-card.png`,
-        imageWidth: 295,
-        imageHeight: 386,
+        imageWidth: 375,
+        imageHeight: 242,
         link: {
           mobileWebUrl: targetUrl,
           webUrl: targetUrl,


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #87 

## 🌱 주요 변경 사항
- 화이트데이 카카오톡 공유하기 버튼 이미지 크기 조정

## 📸 스크린샷 (선택)
<img width="210" height="249" alt="image" src="https://github.com/user-attachments/assets/6ed58bcf-6fdc-496e-93f8-3d230bb33540" />
