### PR TITLE
[#105] - 공통 Icon 컴포넌트 색상 적용

### DIFF
--- a/src/components/common/icon/icon.css
+++ b/src/components/common/icon/icon.css
@@ -1,0 +1,7 @@
+.app-icon {
+  display: inline-block;
+}
+
+.app-icon.app-icon-colored path {
+  fill: var(--icon-color) !important;
+}

--- a/src/components/common/icon/icon.tsx
+++ b/src/components/common/icon/icon.tsx
@@ -1,4 +1,6 @@
-import { iconMap, IconTypes } from '@/src/components/common/icon/icon-map';
+import { iconMap, IconTypes } from "@/src/components/common/icon/icon-map";
+
+import "./icon.css";
 
 interface IconProps {
   name: IconTypes;
@@ -32,10 +34,16 @@ export default function Icon({
       width={w}
       {...(height ? { height } : {})}
       onClick={onClick}
-      role={onClick ? 'button' : undefined}
-      className={className}
-      style={style}
-      {...(color ? { color } : {})}
+      role={onClick ? "button" : undefined}
+      className={`app-icon ${color ? "app-icon-colored" : ""} ${className ?? ""}`}
+      style={
+        color
+          ? ({
+              ...style,
+              ["--icon-color" as string]: color,
+            } as React.CSSProperties)
+          : style
+      }
     />
   );
 }


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #105 

## 🌱 주요 변경 사항
- SVG 내부 path fill에 색상이 적용되도록 수정
- color prop 미지정 시 원본 SVG 색상이 유지되도록 처리