### PR TITLE
[#119] - 화이트데이 카카오톡 공유하기 description 아이콘 추가

### DIFF
--- a/src/components/white-day/kakao-share-button.tsx
+++ b/src/components/white-day/kakao-share-button.tsx
@@ -26,7 +26,7 @@ export default function KakaoShareButton({
       objectType: "feed",
       content: {
         title: "iBe - 행운 뽑기 | 선물이 도착했어요!",
-        description: `To. ${gift.receiver}\n${mbtiResultTitle}`,
+        description: `To. ${gift.receiver}\n${mbtiResultTitle} 💌`,
         imageUrl: `https://ibe-lucky.vercel.app/white-day/share-thumbnail.png`,
         imageWidth: 375,
         imageHeight: 242,


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #119 

## 🌱 주요 변경 사항
- 화이트데이 카카오톡 공유하기 description 아이콘 추가

## 📸 스크린샷 (선택)
<img width="205" height="282" alt="image" src="https://github.com/user-attachments/assets/69b66143-8b0c-492f-9299-b8071ba5deda" />
