### PR TITLE
[#164] - 세계 반려동물의 날 다시 해보기 버튼 라우팅 경로 수정

### DIFF
--- a/src/components/hello-pet/step-2.tsx
+++ b/src/components/hello-pet/step-2.tsx
@@ -18,7 +18,7 @@ export default function Step2() {
   const [loaded, setLoaded] = useState(false);
 
   const handleClickRetry = () => {
-    router.push("/white-day");
+    router.push("/hello-pet");
     resetHelloPet();
   };
 


### PR DESCRIPTION
## 📌 연관된 이슈 번호

close #164

## 🌱 주요 변경 사항
- 세계 반려동물의 날 다시 해보기 버튼 라우팅 경로 수정 (`/white-day` -> `/hello-pet`)